### PR TITLE
Bug 30 inc and dec

### DIFF
--- a/src/codegen.c
+++ b/src/codegen.c
@@ -357,7 +357,7 @@ void gen(Node_t *node) {
     popPrint("rax");
     asmPrint("  #エピローグ\n");
     asmPrint("  mov rsp, rbp\n");
-    popPrint("rbp");
+    asmPrint("	pop rbp\n");
     asmPrint("  ret\n");
     return;
   }

--- a/testcase/case048_5.c
+++ b/testcase/case048_5.c
@@ -1,0 +1,13 @@
+int main(){
+	int x;
+	x = 5;
+	if(++x != 6){
+		return 1;
+	}
+	printf("%d", x);
+	if(x++ != 6){
+	 	return 1;
+	}
+	return 5;
+}
+


### PR DESCRIPTION
if文で分岐させたりし、複数のreturnが存在する場合に発生するエラーを解消
エピローグ時のpop処理でもアライメントを守るためにpopとpushをカウントしている変数を変更させてしまうことが原因